### PR TITLE
feat: use root tsconfig.json if available

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+# Contributors
+
+This file lists all the people who have contributed to this project. Thanks!
+
+- [AlfonzAlfonz](https://github.com/AlfonzAlfonz)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "View \"prettified\" and nested types in hover tooltips and sidebar.",
   "publisher": "MylesMurphy",
   "license": "MIT",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "icon": "assets/logo.png",
   "engines": {
     "vscode": "^1.44.0"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,23 @@
+import * as path from 'path'
+import * as fs from 'fs/promises'
+
 import { SyntaxKind } from 'ts-morph'
+import * as vscode from 'vscode'
+
+export const getTsConfigPath = async (fileName: string): Promise<string | undefined> => {
+  const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fileName))
+
+  if (folder === undefined) return
+
+  const tsConfigPath = path.resolve(folder.uri.fsPath, 'tsconfig.json')
+
+  try {
+    const stat = await fs.stat(tsConfigPath)
+    return stat.isFile() ? tsConfigPath : undefined
+  } catch (e) {
+    return undefined
+  }
+}
 
 /**
  * https://github.com/microsoft/TypeScript/blob/main/src/compiler/types.ts

--- a/src/prettify-type.ts
+++ b/src/prettify-type.ts
@@ -1,11 +1,9 @@
 import * as vscode from 'vscode'
 import { Project, IndentationText, SyntaxKind } from 'ts-morph'
 import { ulid } from 'ulid'
-import * as path from 'path'
-import * as fs from 'fs/promises'
 
 import { EXTENSION_ID } from './consts'
-import { hasType, buildDeclarationString, getPrettifyType, formatDeclarationString } from './helpers'
+import { hasType, buildDeclarationString, getPrettifyType, getTsConfigPath, formatDeclarationString } from './helpers'
 
 export async function prettifyType (fileName: string, content: string, offset: number, checkHasType = true): Promise<string | undefined> {
   const config = vscode.workspace.getConfiguration(EXTENSION_ID)
@@ -82,19 +80,4 @@ export async function prettifyType (fileName: string, content: string, offset: n
   const typeString = formatDeclarationString(declarationString)
 
   return typeString
-}
-
-const getTsConfigPath = async (fileName: string): Promise<string | undefined> => {
-  const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fileName))
-
-  if (folder === undefined) return
-
-  const p = path.resolve(folder.uri.fsPath, 'tsconfig.json')
-
-  try {
-    const stat = await fs.stat(p)
-    return stat.isFile() ? p : undefined
-  } catch (e) {
-    return undefined
-  }
 }

--- a/src/prettify-type.ts
+++ b/src/prettify-type.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode'
 import { Project, IndentationText, SyntaxKind } from 'ts-morph'
 import { ulid } from 'ulid'
+import * as path from 'path'
+import * as fs from 'fs/promises'
 
 import { EXTENSION_ID } from './consts'
 import { hasType, buildDeclarationString, getPrettifyType, formatDeclarationString } from './helpers'
@@ -10,7 +12,11 @@ export async function prettifyType (fileName: string, content: string, offset: n
   const viewNestedTypes = config.get('viewNestedTypes', false)
   const ignoredNestedTypes: string[] = config.get('ignoredNestedTypes', [])
 
-  const project = new Project({ manipulationSettings: { indentationText: IndentationText.TwoSpaces } })
+  const project = new Project({
+    manipulationSettings: { indentationText: IndentationText.TwoSpaces },
+    tsConfigFilePath: await getTsConfigPath(fileName),
+    skipAddingFilesFromTsConfig: true
+  })
   const sourceFile = project.addSourceFileAtPath(fileName)
 
   // Use the current document's text as the source file's text, supports unsaved changes
@@ -76,4 +82,19 @@ export async function prettifyType (fileName: string, content: string, offset: n
   const typeString = formatDeclarationString(declarationString)
 
   return typeString
+}
+
+const getTsConfigPath = async (fileName: string): Promise<string | undefined> => {
+  const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fileName))
+
+  if (folder === undefined) return
+
+  const p = path.resolve(folder.uri.fsPath, 'tsconfig.json')
+
+  try {
+    const stat = await fs.stat(p)
+    return stat.isFile() ? p : undefined
+  } catch (e) {
+    return undefined
+  }
 }


### PR DESCRIPTION
Right now prettify-ts may resolve some types incorrectly because it is missing path to `tsconfig.json` file. This is issue for example when `allowJs` and `checkJs` flags are enabled in the `tsconfig.json` and project relies on importing js files. This can be fixed in `prettifyType` function when ts-morph `Project` is instanciated:

```ts
  const project = new Project({
    manipulationSettings: { indentationText: IndentationText.TwoSpaces },
    tsConfigFilePath: '...'
  })
```

This is implementation of trying to find `tsconfig.json` in the root workspace folder of the current file. This may not work perfectly in monorepos, where multiple `tsconfig.json` may be present in subfolder, but I'd say that this is good enough and this implementation only used a single filesystem call to test whether the tsconfig file exists. Alternatively this can be implemented by checking the file's parent directories to find existing tsconfig. This would result in multiple fs calls because the config would be usually found near the root.