### PR TITLE
feat!: type tree rework and excess properties handling

### DIFF
--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -2,7 +2,7 @@
 
 This project is a TypeScript Language Server Plugin that generates a tree-like structure representing the type information of TypeScript entities. It recursively traverses the types and builds a comprehensive tree, providing a structured view of the types and their relationships.
 
-The plugin handles various TypeScript types including basic types, union types, and complex object types. It also takes care of circular references to prevent infinite recursion. The depth of recursion is configurable, and certain types can be skipped if needed.
+The plugin handles various TypeScript types including references types, union types, and complex object types. It also takes care of circular references to prevent infinite recursion. The depth of recursion is configurable, and certain types can be skipped if needed.
 
 This tool is particularly useful for understanding complex type structures in TypeScript projects, aiding in debugging, documentation, and code comprehension.
 

--- a/packages/typescript-plugin/src/type-tree/types.ts
+++ b/packages/typescript-plugin/src/type-tree/types.ts
@@ -6,8 +6,12 @@ export type TypeFunctionSignature = { returnType: TypeTree, parameters: TypeFunc
 
 /**
  * TypeTree is a tree representation of a TypeScript type.
+ * Discriminated by the `kind` field.
  */
-export type TypeTree = { typeName: string } & (
+export type TypeTree = {
+  typeName: string
+  depth: number
+} & (
   | { kind: 'union', excessMembers: number, types: TypeTree[] }
   | { kind: 'intersection', types: TypeTree[] }
   | { kind: 'object', excessProperties: number, properties: TypeProperty[] }
@@ -15,7 +19,8 @@ export type TypeTree = { typeName: string } & (
   | { kind: 'function', signatures: TypeFunctionSignature[] }
   | { kind: 'promise', type: TypeTree }
   | { kind: 'enum', member: string }
-  | { kind: 'basic' } // https://www.typescriptlang.org/docs/handbook/basic-types.html
+  | { kind: 'primitive' } // string, number, boolean, symbol, bigint, undefined, null, void, never, any
+  | { kind: 'reference' } // Named types like classes, interfaces, type aliases, etc. when maxDepth is reached
 )
 
 /**

--- a/packages/typescript-plugin/src/type-tree/types.ts
+++ b/packages/typescript-plugin/src/type-tree/types.ts
@@ -1,17 +1,16 @@
 import type * as ts from 'typescript'
 
-export type TypeProperty = { name: string, readonly: boolean, type: TypeTree }
-export type TypeFunctionParameter = { name: string, isRestParameter: boolean, type: TypeTree }
+export type TypeProperty = { name: string, optional: boolean, readonly: boolean, type: TypeTree }
+export type TypeFunctionParameter = { name: string, optional: boolean, isRestParameter: boolean, type: TypeTree }
 export type TypeFunctionSignature = { returnType: TypeTree, parameters: TypeFunctionParameter[] }
+
+// TODO: Make "promise" into "generic" and add a "typeArguments" field
 
 /**
  * TypeTree is a tree representation of a TypeScript type.
  * Discriminated by the `kind` field.
  */
-export type TypeTree = {
-  typeName: string
-  depth: number
-} & (
+export type TypeTree = { typeName: string } & (
   | { kind: 'union', excessMembers: number, types: TypeTree[] }
   | { kind: 'intersection', types: TypeTree[] }
   | { kind: 'object', excessProperties: number, properties: TypeProperty[] }
@@ -29,5 +28,6 @@ export type TypeTree = {
 export type TypeInfo = {
   typeTree: TypeTree
   syntaxKind: ts.SyntaxKind
+  variableDeclarationKind?: 'let' | 'const' | 'var'
   name: string
 }

--- a/packages/typescript-plugin/src/type-tree/types.ts
+++ b/packages/typescript-plugin/src/type-tree/types.ts
@@ -28,6 +28,5 @@ export type TypeTree = { typeName: string } & (
 export type TypeInfo = {
   typeTree: TypeTree
   syntaxKind: ts.SyntaxKind
-  variableDeclarationKind?: 'let' | 'const' | 'var'
   name: string
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.3.3"
   },
   "displayName": "Prettify TypeScript: Better Type Previews",
-  "description": "View \"prettified\" and nested types in hover tooltips and sidebar.",
+  "description": "View \"prettified\" and nested types in hover tooltips.",
   "preview": true,
   "icon": "assets/logo.png",
   "engines": {

--- a/packages/vscode-extension/src/hover-provider.ts
+++ b/packages/vscode-extension/src/hover-provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
-import type { PrettifyRequest, TypeInfo } from './types'
+import type { PrettifyRequest } from './types'
+import type { TypeInfo } from '@prettify-ts/typescript-plugin/src/type-tree/types'
 import { prettyPrintTypeString, getSyntaxKindDeclaration, stringifyTypeTree, sanitizeString } from './stringify-type-tree'
 
 export function registerHoverProvider (context: vscode.ExtensionContext): void {

--- a/packages/vscode-extension/src/types.ts
+++ b/packages/vscode-extension/src/types.ts
@@ -1,32 +1,3 @@
-import type * as ts from 'typescript'
-
-export type TypeProperty = { name: string, readonly: boolean, type: TypeTree }
-export type TypeFunctionParameter = { name: string, isRestParameter: boolean, type: TypeTree }
-export type TypeFunctionSignature = { returnType: TypeTree, parameters: TypeFunctionParameter[] }
-
-/**
- * TypeTree is a tree representation of a TypeScript type.
- */
-export type TypeTree = { typeName: string } & (
-  | { kind: 'union', excessMembers: number, types: TypeTree[] }
-  | { kind: 'intersection', types: TypeTree[] }
-  | { kind: 'object', excessProperties: number, properties: TypeProperty[] }
-  | { kind: 'array', readonly: boolean, elementType: TypeTree }
-  | { kind: 'function', signatures: TypeFunctionSignature[] }
-  | { kind: 'promise', type: TypeTree }
-  | { kind: 'enum', member: string }
-  | { kind: 'basic' } // https://www.typescriptlang.org/docs/handbook/basic-types.html
-)
-
-/**
- * TypeInfo contains the type information of a TypeScript node.
- */
-export type TypeInfo = {
-  typeTree: TypeTree
-  syntaxKind: ts.SyntaxKind
-  name: string
-}
-
 export type PrettifyOptions = {
   hidePrivateProperties: boolean
   maxDepth: number


### PR DESCRIPTION
This pull request includes several changes to improve the TypeScript plugin's type tree generation and handling, as well as updates to the associated VSCode extension. The most important changes include enhancements to type handling, refactoring for better readability, and updates to the VSCode extension's description and imports.

### Improvements to Type Handling:
* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R72-R124): Added handling for optional properties, improved handling of union and intersection types, and updated the `getTypeTree` function to better handle depth and excess properties. [[1]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R72-R124) [[2]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L102-R189) [[3]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L149-R232) [[4]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L173-R334)
* [`packages/typescript-plugin/src/type-tree/types.ts`](diffhunk://#diff-9b4cd2ee074cec8cbd29ddf96b8f4ea0f4d1234ec2cf54322af9ea36cae98d7cL3-R11): Updated `TypeProperty` and `TypeFunctionParameter` types to include `optional` property, and changed `kind` from `basic` to `primitive` and `reference` for better clarity. [[1]](diffhunk://#diff-9b4cd2ee074cec8cbd29ddf96b8f4ea0f4d1234ec2cf54322af9ea36cae98d7cL3-R11) [[2]](diffhunk://#diff-9b4cd2ee074cec8cbd29ddf96b8f4ea0f4d1234ec2cf54322af9ea36cae98d7cL18-R22) [[3]](diffhunk://#diff-9b4cd2ee074cec8cbd29ddf96b8f4ea0f4d1234ec2cf54322af9ea36cae98d7cR31)

### Refactoring for Readability:
* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-72e6d8425f48db345769d2819a9e7bb150ce0a5e0465566910937cafe5858102L12-R31): Refactored the `getDescendantAtRange` function to simplify the logic and improve readability.
* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R361-R363): Added several helper functions to check if properties are public, readonly, or optional, and to get the name of index identifiers. [[1]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R361-R363) [[2]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R416-R418) [[3]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R443-R445) [[4]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R460-R485)

### Updates to VSCode Extension:
* [`packages/vscode-extension/package.json`](diffhunk://#diff-41ef0db31db6ae1a96349d902b1f423d33e2b104ad20d0b25f5eae835bc5d5c5L27-R27): Updated the extension description to remove "sidebar" from the features list.
* [`packages/vscode-extension/src/hover-provider.ts`](diffhunk://#diff-89299fc7ab7af17408aff2299c93bd2166309aaf826fad9139cd3aa21c988d04L2-R3): Updated import paths for `TypeInfo` to use the TypeScript plugin's types.

### Documentation Update:
* [`packages/typescript-plugin/README.md`](diffhunk://#diff-ab1161abf4b8f3562663897abc85779b1811795ec338af8ba3800ee37c0a619fL5-R5): Updated the description to correctly mention "reference types" instead of "basic types".