### PR TITLE
feat: toggle command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -54,9 +54,18 @@
         "enableForWorkspaceTypeScriptVersions": true
       }
     ],
+    "commands": [{
+      "command": "prettify-ts.toggle",
+      "title": "Prettify: Toggle"
+    }],
     "configuration": {
       "title": "Prettify TS",
       "properties": {
+        "prettify-ts.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable Prettify TS."
+        },
         "prettify-ts.typeIndentation": {
           "type": "number",
           "default": 4,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -56,7 +56,7 @@
     ],
     "commands": [{
       "command": "prettify-ts.toggle",
-      "title": "Prettify: Toggle"
+      "title": "Prettify TS: Toggle Preview"
     }],
     "configuration": {
       "title": "Prettify TS",

--- a/packages/vscode-extension/src/commands-provider.ts
+++ b/packages/vscode-extension/src/commands-provider.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode'
+
+export function registerCommands (context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('prettify-ts.toggle', async (option?: boolean) => {
+      const config = vscode.workspace.getConfiguration('prettify-ts')
+      if (option === true || option === false) {
+        await config.update('enableHover', option, vscode.ConfigurationTarget.Global)
+        return
+      }
+
+      await config.update('enabled', !config.get('enabled', true), vscode.ConfigurationTarget.Global)
+    })
+  )
+}

--- a/packages/vscode-extension/src/commands-provider.ts
+++ b/packages/vscode-extension/src/commands-provider.ts
@@ -5,7 +5,7 @@ export function registerCommands (context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('prettify-ts.toggle', async (option?: boolean) => {
       const config = vscode.workspace.getConfiguration('prettify-ts')
       if (option === true || option === false) {
-        await config.update('enableHover', option, vscode.ConfigurationTarget.Global)
+        await config.update('enabled', option, vscode.ConfigurationTarget.Global)
         return
       }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,6 +1,8 @@
 import type * as vscode from 'vscode'
 import { registerHoverProvider } from './hover-provider'
+import { registerCommands } from './commands-provider'
 
 export function activate (context: vscode.ExtensionContext): void {
   registerHoverProvider(context)
+  registerCommands(context)
 }

--- a/packages/vscode-extension/src/hover-provider.ts
+++ b/packages/vscode-extension/src/hover-provider.ts
@@ -9,6 +9,8 @@ export function registerHoverProvider (context: vscode.ExtensionContext): void {
     position: vscode.Position
   ): Promise<vscode.Hover | undefined> {
     const config = vscode.workspace.getConfiguration('prettify-ts')
+    if (!config.get('enabled', true)) return
+
     const indentation = config.get('typeIndentation', 4)
     const maxCharacters = config.get('maxCharacters', 20000)
 
@@ -58,7 +60,12 @@ export function registerHoverProvider (context: vscode.ExtensionContext): void {
     }
 
     // Ignore hover if the type is already displayed from TS quick info
-    if (declaration.startsWith('type') || declaration.startsWith('const') || declaration.startsWith('function')) {
+    if (declaration.startsWith('type') ||
+        declaration.startsWith('const') ||
+        declaration.startsWith('let') ||
+        declaration.startsWith('var') ||
+        declaration.startsWith('function')
+    ) {
       const quickInfo: any = await vscode.commands.executeCommand('typescript.tsserverRequest', 'quickinfo', location)
       const quickInfoDisplayString: string = quickInfo?.body?.displayString
 


### PR DESCRIPTION
This pull request includes several updates to the TypeScript plugin and VS Code extension to enhance functionality and improve code maintainability. Key changes include handling import specifiers in type information retrieval, adding a new command to toggle the Prettify TS feature, and updating hover provider logic to respect the enabled configuration.

### TypeScript Plugin Enhancements:
* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L40-R56): Improved `getTypeInfoAtPosition` to handle `ImportSpecifier` by resolving aliased symbols and adjusted the logic for using declared types.

### VS Code Extension Enhancements:
* [`packages/vscode-extension/package.json`](diffhunk://#diff-41ef0db31db6ae1a96349d902b1f423d33e2b104ad20d0b25f5eae835bc5d5c5R57-R68): Added a new command `prettify-ts.toggle` to the extension's commands and updated the configuration to include an `enabled` property for toggling Prettify TS.
* [`packages/vscode-extension/src/commands-provider.ts`](diffhunk://#diff-b40059d4bcc0693e66603eb7e461ea5752ead702b0d81ab5af65ea3b3aebe2b2R1-R15): Introduced `registerCommands` function to register the new toggle command for Prettify TS.
* [`packages/vscode-extension/src/extension.ts`](diffhunk://#diff-4c90b03b52f52f0b353937581a6f678abab846759e4ebe0fc8064e3004ff0164R3-R7): Updated the `activate` function to register the new commands along with the existing hover provider.
* [`packages/vscode-extension/src/hover-provider.ts`](diffhunk://#diff-89299fc7ab7af17408aff2299c93bd2166309aaf826fad9139cd3aa21c988d04R12-R13): Modified the hover provider to respect the `enabled` configuration and expanded the conditions to ignore hover for additional declaration types (`let`, `var`). [[1]](diffhunk://#diff-89299fc7ab7af17408aff2299c93bd2166309aaf826fad9139cd3aa21c988d04R12-R13) [[2]](diffhunk://#diff-89299fc7ab7af17408aff2299c93bd2166309aaf826fad9139cd3aa21c988d04L61-R68)