### PR TITLE
feat: constructor support

### DIFF
--- a/packages/typescript-plugin/src/type-tree/index.ts
+++ b/packages/typescript-plugin/src/type-tree/index.ts
@@ -109,7 +109,7 @@ function getConstructorTypeInfo (type: ts.Type, typeChecker: ts.TypeChecker, nam
   const params = type.getConstructSignatures()[0]!.parameters
   const paramTypes = params.map(p => typeChecker.getTypeOfSymbol(p))
   const parameters = paramTypes.map((t, index) => {
-    const declaration = t.symbol?.declarations?.[0]
+    const declaration = params[index]?.declarations?.[0]
     const isRestParameter = Boolean(declaration && typescript.isParameter(declaration) && !!declaration.dotDotDotToken)
     const optional = Boolean(declaration && typescript.isParameter(declaration) && !!declaration.questionToken)
 

--- a/packages/vscode-extension/src/stringify-type-tree.ts
+++ b/packages/vscode-extension/src/stringify-type-tree.ts
@@ -13,7 +13,7 @@ export function stringifyTypeTree (typeTree: TypeTree, anonymousFunction = true)
   if (typeTree.kind === 'union') {
     const unionString = typeTree.types.map(t => stringifyTypeTree(t)).join(' | ')
     if (typeTree.excessMembers > 0) {
-      return `${unionString} | ... ${typeTree.excessMembers} more;`
+      return `${unionString} | ... ${typeTree.excessMembers} more`
     }
 
     return unionString

--- a/packages/vscode-extension/src/stringify-type-tree.ts
+++ b/packages/vscode-extension/src/stringify-type-tree.ts
@@ -136,6 +136,7 @@ export function getSyntaxKindDeclaration (syntaxKind: SyntaxKind, typeName: stri
     case SyntaxKind.MethodSignature:
     case SyntaxKind.GetAccessor:
     case SyntaxKind.SetAccessor:
+    case SyntaxKind.Constructor:
       return `function ${typeName}`
 
     case SyntaxKind.LetKeyword:


### PR DESCRIPTION
This pull request includes several changes to improve the handling and display of type information in the TypeScript plugin. The most important changes include adding support for displaying constructor information for classes and refactoring the `getTypeInfoAtPosition` function. 

Improvements to type information handling:

* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R50-R65): Added logic to display constructor information for classes, including a new `getConstructorTypeInfo` function. [[1]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R50-R65) [[2]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R104-R125)
* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L61-L67): Refactored the `getTypeInfoAtPosition` function to streamline the type and syntax kind determination.

Enhancements to syntax kind declaration:

* [`packages/vscode-extension/src/stringify-type-tree.ts`](diffhunk://#diff-8d5b642a10bfba35a53585447423d3a3309cde9380dc8fb0d1f86808c8f7fc30R139): Added support for the `Constructor` syntax kind in the `getSyntaxKindDeclaration` function.