### PR TITLE
feat: tuples

### DIFF
--- a/packages/typescript-plugin/src/type-tree/index.ts
+++ b/packages/typescript-plugin/src/type-tree/index.ts
@@ -280,6 +280,20 @@ function getTypeTree (type: ts.Type, depth: number, visited: Set<ts.Type>): Type
     }
   }
 
+  if (checker.isTupleType(type)) {
+    const elementTypes = checker
+      .getTypeArguments(type as ts.TupleTypeReference)
+      .map(t => getTypeTree(t, depth, new Set(visited)))
+    const readonly = (type as ts.TupleTypeReference)?.target?.readonly ?? false
+
+    return {
+      kind: 'tuple',
+      typeName,
+      readonly,
+      elementTypes
+    }
+  }
+
   if (checker.isArrayType(type)) {
     if (!options.unwrapArrays) {
       depth = options.maxDepth

--- a/packages/typescript-plugin/src/type-tree/types.ts
+++ b/packages/typescript-plugin/src/type-tree/types.ts
@@ -14,6 +14,7 @@ export type TypeTree = { typeName: string } & (
   | { kind: 'union', excessMembers: number, types: TypeTree[] }
   | { kind: 'intersection', types: TypeTree[] }
   | { kind: 'object', excessProperties: number, properties: TypeProperty[] }
+  | { kind: 'tuple', readonly: boolean, elementTypes: TypeTree[] }
   | { kind: 'array', readonly: boolean, elementType: TypeTree }
   | { kind: 'function', signatures: TypeFunctionSignature[] }
   | { kind: 'promise', type: TypeTree }

--- a/packages/vscode-extension/src/stringify-type-tree.ts
+++ b/packages/vscode-extension/src/stringify-type-tree.ts
@@ -44,6 +44,12 @@ export function stringifyTypeTree (typeTree: TypeTree, anonymousFunction = true)
     return `{ ${propertiesString} }`
   }
 
+  if (typeTree.kind === 'tuple') {
+    const elementTypesString = typeTree.elementTypes.map(t => stringifyTypeTree(t)).join(', ')
+
+    return `${typeTree.readonly ? 'readonly ' : ''}[${elementTypesString}]`
+  }
+
   if (typeTree.kind === 'array') {
     let elementTypeString = stringifyTypeTree(typeTree.elementType)
     if (elementTypeString.includes('|') || elementTypeString.includes('&')) {


### PR DESCRIPTION
This pull request introduces support for tuple types in the TypeScript plugin. The changes include modifications to handle tuple types in the type tree and to stringify tuple types.

### Support for tuple types:

* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120R283-R296): Added logic to handle tuple types in the `getTypeTree` function.
* [`packages/typescript-plugin/src/type-tree/types.ts`](diffhunk://#diff-9b4cd2ee074cec8cbd29ddf96b8f4ea0f4d1234ec2cf54322af9ea36cae98d7cR17): Updated the `TypeTree` type definition to include the tuple type structure.

### Stringification of tuple types:

* [`packages/vscode-extension/src/stringify-type-tree.ts`](diffhunk://#diff-8d5b642a10bfba35a53585447423d3a3309cde9380dc8fb0d1f86808c8f7fc30R47-R52): Added logic to stringify tuple types in the `stringifyTypeTree` function.