### PR TITLE
feat: copy type

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -54,9 +54,37 @@
         "enableForWorkspaceTypeScriptVersions": true
       }
     ],
-    "commands": [{
-      "command": "prettify-ts.toggle",
-      "title": "Prettify TS: Toggle Preview"
+    "commands": [
+      {
+        "command": "prettify-ts.toggle",
+        "title": "Toggle Preview",
+        "category": "Prettify TS"
+      },
+      {
+        "command": "prettify-ts.copyPrettifiedType",
+        "title": "Copy Prettified Type",
+        "category": "Prettify TS"
+      },
+      {
+        "command": "prettify-ts.fullCopyPrettifiedType",
+        "title": "Copy Fully Prettified Type",
+        "category": "Prettify TS"
+      }
+    ],
+    "menus": {
+      "editor/context": [{
+        "submenu": "prettify.copy",
+        "group": "9_cutcopypaste",
+        "when": "editorLangId == 'typescript' || editorLangId == 'typescriptreact'"
+      }],
+      "prettify.copy": [
+        { "command": "prettify-ts.copyPrettifiedType" },
+        { "command": "prettify-ts.fullCopyPrettifiedType" }
+      ]
+    },
+    "submenus": [{
+      "id": "prettify.copy",
+      "label": "Prettify"
     }],
     "configuration": {
       "title": "Prettify TS",

--- a/packages/vscode-extension/src/commands-provider.ts
+++ b/packages/vscode-extension/src/commands-provider.ts
@@ -1,15 +1,94 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { type TypeInfo } from '@prettify-ts/typescript-plugin/src/type-tree/types'
 import * as vscode from 'vscode'
+import { stringifyTypeTree, prettyPrintTypeString, getSyntaxKindDeclaration } from './stringify-type-tree'
+import { type PrettifyRequest } from './types'
+
+const MAX_SETTINGS = 999999999999
 
 export function registerCommands (context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('prettify-ts.toggle', async (option?: boolean) => {
-      const config = vscode.workspace.getConfiguration('prettify-ts')
-      if (option === true || option === false) {
-        await config.update('enabled', option, vscode.ConfigurationTarget.Global)
-        return
-      }
+  const toggleCommand = vscode.commands.registerCommand('prettify-ts.toggle', async (option?: boolean) => {
+    const config = vscode.workspace.getConfiguration('prettify-ts')
+    if (option === true || option === false) {
+      await config.update('enabled', option, vscode.ConfigurationTarget.Global)
+      return
+    }
 
-      await config.update('enabled', !config.get('enabled', true), vscode.ConfigurationTarget.Global)
-    })
-  )
+    await config.update('enabled', !config.get('enabled', true), vscode.ConfigurationTarget.Global)
+  })
+
+  async function copyType (full = false): Promise<void> {
+    const config = vscode.workspace.getConfiguration('prettify-ts')
+    const editor = vscode.window.activeTextEditor
+    if (!editor) return
+
+    const indentation = config.get('typeIndentation', 4)
+    const options = {
+      hidePrivateProperties: config.get('hidePrivateProperties', true),
+      maxDepth: config.get('maxDepth', 2),
+      maxProperties: config.get('maxProperties', 100),
+      maxSubProperties: config.get('maxSubProperties', 5),
+      maxUnionMembers: config.get('maxUnionMembers', 15),
+      skippedTypeNames: config.get('skippedTypeNames', []),
+      unwrapArrays: config.get('unwrapArrays', true),
+      unwrapFunctions: config.get('unwrapFunctions', true),
+      unwrapPromises: config.get('unwrapPromises', true)
+    }
+
+    if (full) {
+      options.maxDepth = MAX_SETTINGS
+      options.maxProperties = MAX_SETTINGS
+      options.maxSubProperties = MAX_SETTINGS
+      options.maxUnionMembers = MAX_SETTINGS
+      options.unwrapArrays = true
+      options.unwrapFunctions = true
+      options.unwrapPromises = true
+    }
+
+    const request: PrettifyRequest = {
+      meta: 'prettify-type-info-request',
+      options
+    }
+
+    const cursorPosition = editor.selection.active
+    const location = {
+      file: editor.document.uri.fsPath,
+      line: cursorPosition.line + 1,
+      offset: cursorPosition.character + 1
+    }
+
+    const response: any = await vscode.commands.executeCommand(
+      'typescript.tsserverRequest',
+      'completionInfo',
+      {
+        ...location,
+        triggerCharacter: request
+      }
+    )
+
+    const prettifyResponse: TypeInfo | undefined = response?.body?.__prettifyResponse
+    if (!prettifyResponse || !prettifyResponse.typeTree) {
+      await vscode.window.showErrorMessage('No type information found at cursor position')
+      return
+    }
+
+    const { typeTree, syntaxKind, name } = prettifyResponse
+
+    const typeString = stringifyTypeTree(typeTree, false)
+    const prettyTypeString = prettyPrintTypeString(typeString, indentation)
+    const declaration = getSyntaxKindDeclaration(syntaxKind, name)
+
+    await vscode.env.clipboard.writeText(declaration + prettyTypeString)
+    await vscode.window.showInformationMessage('Type copied to clipboard')
+  }
+
+  const copyFunction = async () => await copyType().catch(() => vscode.window.showErrorMessage('Failed to copy prettified type'))
+  const fullCopyFunction = async () => await copyType(true).catch(() => vscode.window.showErrorMessage('Failed to copy fully prettified type'))
+
+  const copyCommand = vscode.commands.registerCommand('prettify-ts.copyPrettifiedType', copyFunction)
+  const fullCopyCommand = vscode.commands.registerCommand('prettify-ts.fullCopyPrettifiedType', fullCopyFunction)
+
+  context.subscriptions.push(toggleCommand)
+  context.subscriptions.push(copyCommand)
+  context.subscriptions.push(fullCopyCommand)
 }

--- a/packages/vscode-extension/src/hover-provider.ts
+++ b/packages/vscode-extension/src/hover-provider.ts
@@ -76,7 +76,7 @@ export function registerHoverProvider (context: vscode.ExtensionContext): void {
     }
 
     const hoverText = new vscode.MarkdownString()
-    hoverText.appendCodeblock(`${declaration}${prettyTypeString}`, document.languageId)
+    hoverText.appendCodeblock(declaration + prettyTypeString, document.languageId)
     return new vscode.Hover(hoverText)
   }
 


### PR DESCRIPTION
This pull request introduces several enhancements to the `vscode-extension` package, focusing on adding new commands and improving the functionality of existing ones. The most important changes include adding new commands for copying prettified TypeScript types, updating the `package.json` to include these new commands and their associated menus, and refactoring the `registerCommands` function to handle the new commands.

Enhancements to commands:

* Added new commands `prettify-ts.copyPrettifiedType` and `prettify-ts.fullCopyPrettifiedType` for copying prettified TypeScript types.
* Updated `package.json` to include new commands and their associated menus under the "Prettify TS" category.

Refactoring and improvements:

* Refactored `registerCommands` function in `commands-provider.ts` to include the new copy commands and handle their registration. [[1]](diffhunk://#diff-b40059d4bcc0693e66603eb7e461ea5752ead702b0d81ab5af65ea3b3aebe2b2R1-R10) [[2]](diffhunk://#diff-b40059d4bcc0693e66603eb7e461ea5752ead702b0d81ab5af65ea3b3aebe2b2R19-R93)
* Simplified string concatenation in `registerHoverProvider` function in `hover-provider.ts` for better readability.