### PR TITLE
fix: correct intersection with apparent type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prettify-ts-monorepo",
   "publisher": "MylesMurphy",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "private": true,
   "workspaces": {
     "packages": ["packages/*"]

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prettify-ts/typescript-plugin",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "main": "./out",
   "license": "MIT",
   "private": "true",

--- a/packages/typescript-plugin/src/type-tree/index.ts
+++ b/packages/typescript-plugin/src/type-tree/index.ts
@@ -165,22 +165,11 @@ function getTypeTree (type: ts.Type, depth: number, visited: Set<ts.Type>): Type
   }
 
   // Prevent infinite recursion when encountering circular references
-  // Guarantueed to be a reference if the type has been visited before
   if (visited.has(type)) {
-    if (typeName.includes('{') && apparentType.getProperties().length > 0) {
-      const typeProperties = apparentType.getProperties()
-      const stringIndexType = apparentType.getStringIndexType()
-      const numberIndexType = apparentType.getNumberIndexType()
-
-      let propertiesCount = typeProperties.length
-      if (stringIndexType) propertiesCount += 1
-      if (numberIndexType) propertiesCount += 1
-
+    if (typeName.includes('{') || typeName.includes('[') || typeName.includes('(')) {
       return {
-        kind: 'object',
-        typeName,
-        properties: [],
-        excessProperties: propertiesCount // Return all properties as excess to avoid deeper nesting
+        kind: 'reference',
+        typeName: '...'
       }
     }
 

--- a/packages/typescript-plugin/src/type-tree/types.ts
+++ b/packages/typescript-plugin/src/type-tree/types.ts
@@ -12,7 +12,6 @@ export type TypeFunctionSignature = { returnType: TypeTree, parameters: TypeFunc
  */
 export type TypeTree = { typeName: string } & (
   | { kind: 'union', excessMembers: number, types: TypeTree[] }
-  | { kind: 'intersection', types: TypeTree[] }
   | { kind: 'object', excessProperties: number, properties: TypeProperty[] }
   | { kind: 'tuple', readonly: boolean, elementTypes: TypeTree[] }
   | { kind: 'array', readonly: boolean, elementType: TypeTree }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "MylesMurphy",
   "license": "MIT",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.2.0",
   "main": "./out/extension.js",
   "workspaces": {
     "nohoist": ["**"]

--- a/packages/vscode-extension/src/stringify-type-tree.ts
+++ b/packages/vscode-extension/src/stringify-type-tree.ts
@@ -19,10 +19,6 @@ export function stringifyTypeTree (typeTree: TypeTree, anonymousFunction = true)
     return unionString
   }
 
-  if (typeTree.kind === 'intersection') {
-    return typeTree.types.map(t => stringifyTypeTree(t)).join(' & ')
-  }
-
   if (typeTree.kind === 'object') {
     let propertiesString = typeTree.properties.map(p => {
       const readonly = (p.readonly) ? 'readonly ' : ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,7 +559,7 @@ debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
 
 deep-is@^0.1.3:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
@@ -1160,7 +1160,7 @@ import-fresh@^3.2.1:
 
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 inflight@^1.0.4:
@@ -1836,9 +1836,9 @@ typed-array-length@^1.0.6:
     possible-typed-array-names "^1.0.0"
 
 typescript@^5.3.3, typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+  version "5.7.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This pull request includes several updates to the `typescript-plugin` package to improve the handling of TypeScript types and some version bumps across multiple packages. The most important changes include modifying the `getTypeTree` function to use `apparentType` instead of `type` for better type resolution and removing the handling of intersection types.

Improvements to type handling:

* [`packages/typescript-plugin/src/type-tree/index.ts`](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L153-R186): Modified the `getTypeTree` function to use `apparentType` instead of `type` for various type checks and resolutions, including primitive types, union types, enum members, tuples, arrays, and object properties. This ensures more accurate type handling and prevents infinite recursion with circular references. [[1]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L153-R186) [[2]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L186-R203) [[3]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L283-R260) [[4]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L297-R292) [[5]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L324-R302) [[6]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L365-R342) [[7]](diffhunk://#diff-ddbc3cc1b594017047c644e32b6c16483e273b639fe54698b0f31887371a4120L379-R356)

* [`packages/typescript-plugin/src/type-tree/types.ts`](diffhunk://#diff-9b4cd2ee074cec8cbd29ddf96b8f4ea0f4d1234ec2cf54322af9ea36cae98d7cL15): Removed the `intersection` type from the `TypeTree` type definition.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the version from `0.1.6` to `0.2.0` to reflect the new changes.
* [`packages/typescript-plugin/package.json`](diffhunk://#diff-e0655c89b11bd48abf91729d7658ee405328c32dc515efcd6e56ecd770efa516L3-R3): Updated the version from `0.1.6` to `0.2.0`.
* [`packages/vscode-extension/package.json`](diffhunk://#diff-41ef0db31db6ae1a96349d902b1f423d33e2b104ad20d0b25f5eae835bc5d5c5L6-R6): Updated the version from `0.1.6` to `0.2.0`.

Code simplification:

* [`packages/vscode-extension/src/stringify-type-tree.ts`](diffhunk://#diff-8d5b642a10bfba35a53585447423d3a3309cde9380dc8fb0d1f86808c8f7fc30L22-L25): Removed the handling of intersection types in the `stringifyTypeTree` function.