### PR TITLE
fix: build symlink issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettify-ts-monorepo",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prettify-ts-monorepo",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "18.x",
@@ -5531,7 +5531,7 @@
     },
     "packages/typescript-plugin": {
       "name": "@prettify-ts/typescript-plugin",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@types/ts-expose-internals": "npm:ts-expose-internals@5.4.5",
@@ -5545,7 +5545,7 @@
     },
     "packages/vscode-extension": {
       "name": "prettify-ts",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@prettify-ts/typescript-plugin": "*"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prettify-ts-monorepo",
   "publisher": "MylesMurphy",
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "private": true,
   "workspaces": {
     "packages": [
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "build": "npm run build --workspaces",
     "postbuild": "node ./scripts/post-build.js",
-    "package": "npm ci && npm run build --workspaces && npm run package --workspace=prettify-ts"
+    "package": "npm run build && npm run package --workspace=prettify-ts"
   },
   "devDependencies": {
     "@types/node": "18.x",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prettify-ts/typescript-plugin",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "main": "./out",
   "license": "MIT",
   "private": "true",

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -1,18 +1,21 @@
-**/tsconfig.json
-**/.eslintrc.json
-**/*.map
-**/*.ts
-**/*.ts
-**/*.tsx
-**/*.js.map
-**/.DS_Store
-**/package-lock.json
-**/package.json
-**/.eslintrc.json
-**/*.log
-../../**
+# Ignore all files in the root directory and above
+**
 ../**
-!**/node_modules/@prettify-ts/**
-!./node_modules/@prettify-ts/**
-!**/assets/example.png
-!./assets/example.
+../../**
+
+# Un-ignore (include) only the files and folders you want in the VSIX
+
+# Extension entry point
+!out/extension.js
+
+# Manifest and docs
+!package.json
+!LICENSE
+!README.md
+
+# Only include .png and .svg assets
+!assets/**/*.png
+!assets/**/*.svg
+
+# The built plugin in node_modules
+!node_modules/@prettify-ts/typescript-plugin-dist/**

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "MylesMurphy",
   "license": "MIT",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.3",
   "main": "./out/extension.js",
   "scripts": {
     "build": "tsc",
@@ -48,7 +48,7 @@
   "contributes": {
     "typescriptServerPlugins": [
       {
-        "name": "@prettify-ts/typescript-plugin",
+        "name": "@prettify-ts/typescript-plugin-dist",
         "enableForWorkspaceTypeScriptVersions": true
       }
     ],

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -6,7 +6,10 @@ const fs = require('fs-extra');
 const path = require('node:path');
 
 const pluginDir = path.resolve(__dirname, '../packages/typescript-plugin');
-const extensionNodeModules = path.resolve(__dirname, '../packages/vscode-extension/node_modules/@prettify-ts/typescript-plugin');
+const extensionNodeModules = path.resolve(__dirname, '../packages/vscode-extension/node_modules/@prettify-ts/typescript-plugin-dist');
+
+// Clean the target directory first
+fs.removeSync(extensionNodeModules);
 
 fs.ensureDirSync(extensionNodeModules);
 fs.copySync(path.join(pluginDir, 'package.json'), path.join(extensionNodeModules, 'package.json'));


### PR DESCRIPTION
This pull request includes updates to version numbers, build scripts, and packaging configurations across multiple files, as well as improvements to the `.vscodeignore` file to streamline the VSIX package. The most significant changes involve renaming the TypeScript plugin's distribution folder and updating references to it in the VS Code extension package and build scripts.

### Version Updates
* Updated the version numbers from `0.3.1` to `0.3.3` in `package.json`, `packages/typescript-plugin/package.json`, and `packages/vscode-extension/package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5) [[2]](diffhunk://#diff-e0655c89b11bd48abf91729d7658ee405328c32dc515efcd6e56ecd770efa516L3-R3) [[3]](diffhunk://#diff-41ef0db31db6ae1a96349d902b1f423d33e2b104ad20d0b25f5eae835bc5d5c5L6-R6)

### Build and Packaging Changes
* Modified the `package` script in the root `package.json` to remove `npm ci` for a more streamlined build process.
* Updated the `typescriptServerPlugins` configuration in `packages/vscode-extension/package.json` to reference `@prettify-ts/typescript-plugin-dist` instead of `@prettify-ts/typescript-plugin`.
* Adjusted `scripts/post-build.js` to clean the target directory before copying files and updated the path to the plugin's distribution folder.

### VSIX Packaging Improvements
* Overhauled the `.vscodeignore` file to ignore all files by default and selectively include necessary files and assets for the VSIX package, such as `extension.js`, `package.json`, and specific assets.